### PR TITLE
Substituição de Drop shadow para Box shadow

### DIFF
--- a/src/components/Table/TableContext.tsx
+++ b/src/components/Table/TableContext.tsx
@@ -140,7 +140,7 @@ export const TableProvider = ({
         setPerPage,
         setSelectKey,
       }}>
-      <div className='shadow-gray-600 drop-shadow-[0_0_8px_rgba(30,64,175,0.15)] w-full'>{children}</div>
+      <div className='shadow-gray-600 box-shadow-[0_0_8px_rgba(30,64,175,0.15)] w-full'>{children}</div>
     </TableContext.Provider>
   );
 };


### PR DESCRIPTION
A propriedade "filter" gera um novo contexto de camadas, que altera o referencial de posicionamento para elementos com "position: fixed;". Nesse caso, o "filter: drop-shadow();" impede que o menu principal do sistema fortuna acompanhe o deslize da página. A substituição de "drop-shadow" por "box-shadow" não implica em quaisquer alterações visuais.